### PR TITLE
Update uncontainerized deploy instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ SQAN (formerly RADY-SCA) is a full-stack system solution for extracting, transla
   * generates public/private keys for JSON Web Token signing/verification
 4.  `cp index.sample.js index.js`
   * Modify config/index.js as needed
-5. `cd ../ui/src && cp config.sample.js config.js`
+5. `cd ../ui/src && cp config.example.js config.js`
   * Modify ui/src/config.js as needed
 6.  `yarn install`
 7.  `yarn build`
 8.  Launch API
-  * `npm start` 
+  * `cd ../.. && npm start` 
 9.  Configure nginx to serve API/UI 
 10.  (optional) Load sample dataset (available upon request)
 11.  (optional) Initiate Incoming and QC processes


### PR DESCRIPTION
Don't know how useful this is, but I was tooling around in SQAN this morning, ran into some [very possibly PEBKAC] trouble with the docker build and discovered some issues running through the vanilla build. I corrected them in order to get my local closer to a good state, and wanted to tie this off before moving on.

Note that the current uncontainerized deploy steps also don't appear to account for the needed `auth.jwt` file. I haven't resolved or attempted to resolve this.

Changes:

* Sync'ed UI config step with state of `ui/src` dir.

* Changed `npm start` command to reflect current working directory in deploy steps.

I don't know what the plans are for supporting uncontainerized build & deploy. I would guess they are nonexistent on the deploy side.

Depending on what they are, it might make more sense to overhaul the deploy steps to reference the docker flow. And have a separate section for local builds.