### PR TITLE
Add cross-platform 'nix support for node scripts

### DIFF
--- a/api/sqan.js
+++ b/api/sqan.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 'use strict';
 
 var server = require('./server');

--- a/bin/incoming.js
+++ b/bin/incoming.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 
 //node
 var fs = require('fs');

--- a/bin/qc.js
+++ b/bin/qc.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 'use strict';
 
 //contrib


### PR DESCRIPTION
Fixes node scripts so they will run in 'nix environments (like my MacOS one) where node isn't accessible at `/usr/bin/node`

I had to fix this for my local following a vanilla build path

Again, this may not be desirable if the only supported build and deploy path is a dockerized one where the spec'ed node path is always valid